### PR TITLE
Add basic site for game releases

### DIFF
--- a/games/quest-for-gold.html
+++ b/games/quest-for-gold.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quest for Gold</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Quest for Gold</h1>
+      <p>Released: August 2022</p>
+    </header>
+    <main>
+      <p>
+        Delve into ancient ruins and solve puzzles to uncover legendary
+        treasures.
+      </p>
+    </main>
+    <footer>
+      <p><a href="../index.html">Back to releases</a></p>
+    </footer>
+  </body>
+</html>

--- a/games/space-adventure.html
+++ b/games/space-adventure.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Space Adventure</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Space Adventure</h1>
+      <p>Released: January 2023</p>
+    </header>
+    <main>
+      <p>
+        Blast off into the stars and explore uncharted galaxies in this
+        action-packed space exploration game.
+      </p>
+    </main>
+    <footer>
+      <p><a href="../index.html">Back to releases</a></p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,30 @@
-<!DOCTYPE html>
-<html>
-<body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
-</body>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Game Releases</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Game Releases</h1>
+      <p>Welcome to the official hub for my indie games.</p>
+    </header>
+    <main>
+      <section class="game-list">
+        <article class="game">
+          <h2><a href="games/space-adventure.html">Space Adventure</a></h2>
+          <p>Embark on a cosmic journey. Released: January 2023.</p>
+        </article>
+        <article class="game">
+          <h2><a href="games/quest-for-gold.html">Quest for Gold</a></h2>
+          <p>Seek treasure in a pixelated world. Released: August 2022.</p>
+        </article>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2024 My Game Studio</p>
+    </footer>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #1e1e1e;
+  color: #f5f5f5;
+}
+header,
+footer {
+  background: #333;
+  padding: 1rem;
+  text-align: center;
+}
+.game-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+.game {
+  background: #2c2c2c;
+  padding: 1rem;
+  border-radius: 4px;
+}
+a {
+  color: #4ea3ff;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Introduce styled homepage listing two example game releases
- Add individual pages for "Space Adventure" and "Quest for Gold"
- Provide shared dark theme stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dc392018832da55017b5c694bdaa